### PR TITLE
fix: properly manage NotFound & MethodNotAllowed request errors

### DIFF
--- a/internal/service/r_mock_test.go
+++ b/internal/service/r_mock_test.go
@@ -225,6 +225,7 @@ func Test_handleNotFound(t *testing.T) {
 			},
 		},
 	}
+	t.Parallel()
 	for _, testToRun := range tests {
 		test := testToRun
 		t.Run(test.name, func(tt *testing.T) {
@@ -269,6 +270,7 @@ func Test_handleMethodNotAllowed(t *testing.T) {
 			},
 		},
 	}
+	t.Parallel()
 	for _, testToRun := range tests {
 		test := testToRun
 		t.Run(test.name, func(tt *testing.T) {

--- a/internal/service/r_mock_test.go
+++ b/internal/service/r_mock_test.go
@@ -192,6 +192,94 @@ func Test_service_handleBatchMock(t *testing.T) {
 	}
 }
 
+func Test_handleNotFound(t *testing.T) {
+	svc := &service{
+		logger: newStructuredLogger(),
+	}
+	tests := []struct {
+		name         string
+		setupRequest func() *http.Request
+		respHandler  func(tt *testing.T, resp *httptest.ResponseRecorder)
+	}{
+		{
+			name: "request to unknown route",
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/v1/mock/unknown", nil)
+				return req
+			},
+			respHandler: func(tt *testing.T, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusNotFound {
+					tt.Errorf("expected status code %d, got %d", http.StatusNotFound, resp.Code)
+				}
+				if resp.Header().Get("Content-Type") != "application/json" {
+					tt.Errorf("expected content type %s, got %s", "application/json", resp.Header().Get("Content-Type"))
+				}
+				var errorResponse api.HTTPErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &errorResponse); err != nil {
+					tt.Errorf("could not unmarshal response body: %+v", err)
+				}
+
+				if errorResponse.Error.Message != "not found" || errorResponse.Error.Code != api.CodeNotFound {
+					tt.Errorf("expected error message %s and code %d, got %s and %d", "not found", api.CodeNotFound, errorResponse.Error.Message, errorResponse.Error.Code)
+				}
+			},
+		},
+	}
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			resp := httptest.NewRecorder()
+			svc.handleNotFound(resp, test.setupRequest())
+			test.respHandler(tt, resp)
+		})
+	}
+}
+
+func Test_handleMethodNotAllowed(t *testing.T) {
+	svc := &service{
+		logger: newStructuredLogger(),
+	}
+	tests := []struct {
+		name         string
+		setupRequest func() *http.Request
+		respHandler  func(tt *testing.T, resp *httptest.ResponseRecorder)
+	}{
+		{
+			name: "request to unknown route",
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/v1/mock/unknown", nil)
+				return req
+			},
+			respHandler: func(tt *testing.T, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusNotFound {
+					tt.Errorf("expected status code %d, got %d", http.StatusNotFound, resp.Code)
+				}
+				if resp.Header().Get("Content-Type") != "application/json" {
+					tt.Errorf("expected content type %s, got %s", "application/json", resp.Header().Get("Content-Type"))
+				}
+				var errorResponse api.HTTPErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &errorResponse); err != nil {
+					tt.Errorf("could not unmarshal response body: %+v", err)
+				}
+
+				if errorResponse.Error.Message != "method not allowed" || errorResponse.Error.Code != api.CodeMethodNotAllowed {
+					tt.Errorf("expected error message %s and code %d, got %s and %d", "method not allowed", api.CodeMethodNotAllowed, errorResponse.Error.Message, errorResponse.Error.Code)
+				}
+			},
+		},
+	}
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			resp := httptest.NewRecorder()
+			svc.handleMethodNotAllowed(resp, test.setupRequest())
+			test.respHandler(tt, resp)
+		})
+	}
+}
+
 func Test_shouldFail(t *testing.T) {
 	type args struct {
 		successRatio    float64

--- a/pkg/api/codes.go
+++ b/pkg/api/codes.go
@@ -1,0 +1,9 @@
+package api
+
+const (
+	// 1xxx errors
+	requestBase          = 1000
+	CodeInvalidBody      = requestBase + 1
+	CodeNotFound         = requestBase + 2
+	CodeMethodNotAllowed = requestBase + 3
+)


### PR DESCRIPTION
**Description of the change**

This PR ensures NotFound & MethodNotAllowed request errors are properly managed.

**Benefits**

Request to unsupported paths or using not allowed methods to be properly managed.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

It also increments the test coverage on router by 13%.
