### PR TITLE
feat: add support for delayed responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ COPY dist/api-mock_linux_${TARGETARCH}*/api-mock /usr/local/bin/
 USER 1001
 EXPOSE 8080
 ENV API_TOKEN="" \
+    LOG_LEVEL="info" \
     FAILURE_RESP_BODY="{\"success\": false}" \
     FAILURE_RESP_CODE=400 \
     METHODS="GET,POST" \
+    RESP_DELAY=0 \
     SUB_ROUTES="" \
     SUCCESS_RESP_BODY="{\"success\": true}" \
     SUCCESS_RESP_CODE=200 \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The API mock can be configured with the following environment variables:
 | Variable | Description | Default |
 | -------- | ----------- | ------- |
 | `PORT` | The port to listen on | `8080` |
+| `LOG_LEVEL` | The log level | `info` |
 | `API_TOKEN` | Bearer token to authenticate requests | `` |
 | `FAILURE_RESP_BODY` | The response body to return when mocking a failure | `{"success": "false"}` |
 | `FAILURE_RESP_CODE` | The HTTP status code to return when mocking a failure | `400` |
@@ -35,6 +36,7 @@ The API mock can be configured with the following environment variables:
 | `SUCCESS_RESP_CODE` | The HTTP status code to return when mocking a success | `200` |
 | `SUCCESS_RATIO` | The ratio of success to failure responses | `1.0` |
 | `METHODS` | The HTTP methods to mock | `GET,POST` |
+| `RESP_DELAY` | The response delay (in milliseconds) | `0` |
 | `SUB_ROUTES` | The sub routes to mock | `` |
 | `RATE_LIMIT` | The API rate limit (requests per second) | `1000` |
 | `RATE_EXCEEDED_RESP_BODY` | The response body to return when mocking a rate exceeded | `{"success": "false", "error": "rate limit exceeded"}` |

--- a/internal/service/logger.go
+++ b/internal/service/logger.go
@@ -10,9 +10,10 @@ import (
 )
 
 // newStructuredLogger creates a new structured logger compatible with GCP logging syntax
-func newStructuredLogger() *slog.Logger {
+func newStructuredLogger(level slog.Level) *slog.Logger {
 	return slog.New(
 		slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+			Level: level,
 			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 				switch a.Key {
 				case slog.LevelKey:

--- a/internal/service/r_mock.go
+++ b/internal/service/r_mock.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/go-chi/render"
 
@@ -28,6 +29,11 @@ func (svc *service) incReqCounter() func(next http.Handler) http.Handler {
 // handleMock mocks request handling
 // Route: /v1/mock/*
 func (svc *service) handleMock(w http.ResponseWriter, r *http.Request) {
+	// Delay response
+	if svc.cfg.respDelay > 0 {
+		time.Sleep(svc.cfg.respDelay)
+	}
+
 	// Return failure based on success ratio and requests counter
 	if shouldFail(svc.cfg.successRatio, svc.reqCounter) {
 		render.Status(r, svc.cfg.failureCode)

--- a/internal/service/r_mock_test.go
+++ b/internal/service/r_mock_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -23,7 +24,7 @@ func Test_service_handleMock(t *testing.T) {
 			methods:         []string{http.MethodGet},
 			subRoutes:       []string{"/foo"},
 		},
-		logger: newStructuredLogger(),
+		logger: newStructuredLogger(slog.LevelDebug),
 	}
 
 	tests := []struct {
@@ -129,7 +130,7 @@ func Test_service_handleBatchMock(t *testing.T) {
 			methods:         []string{http.MethodGet},
 			subRoutes:       []string{"/foo"},
 		},
-		logger: newStructuredLogger(),
+		logger: newStructuredLogger(slog.LevelDebug),
 	}
 
 	tests := []struct {
@@ -194,7 +195,7 @@ func Test_service_handleBatchMock(t *testing.T) {
 
 func Test_handleNotFound(t *testing.T) {
 	svc := &service{
-		logger: newStructuredLogger(),
+		logger: newStructuredLogger(slog.LevelDebug),
 	}
 	tests := []struct {
 		name         string
@@ -239,7 +240,7 @@ func Test_handleNotFound(t *testing.T) {
 
 func Test_handleMethodNotAllowed(t *testing.T) {
 	svc := &service{
-		logger: newStructuredLogger(),
+		logger: newStructuredLogger(slog.LevelDebug),
 	}
 	tests := []struct {
 		name         string

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test_LoadConfigFromEnv(t *testing.T) {
 	type env struct {
-		port, apiToken, failureRespCode, failureRespBody, successRespCode, successRespBody, successRatio, rateLimit, rateExceededRespBody, methods, subRoutes string
+		port, apiToken, respDelay, failureRespCode, failureRespBody, successRespCode, successRespBody, successRatio, rateLimit, rateExceededRespBody, methods, subRoutes string
 	}
 	tests := []struct {
 		name    string
@@ -64,6 +64,14 @@ func Test_LoadConfigFromEnv(t *testing.T) {
 			name: "Invalid port",
 			env: env{
 				port: "not-a-number",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Invalid response delay",
+			env: env{
+				respDelay: "not-a-number",
 			},
 			want:    nil,
 			wantErr: true,
@@ -137,6 +145,7 @@ func Test_LoadConfigFromEnv(t *testing.T) {
 		t.Run(test.name, func(tt *testing.T) {
 			tt.Setenv("PORT", test.env.port)
 			tt.Setenv("API_TOKEN", test.env.apiToken)
+			tt.Setenv("RESP_DELAY", test.env.respDelay)
 			tt.Setenv("FAILURE_RESP_CODE", test.env.failureRespCode)
 			tt.Setenv("FAILURE_RESP_BODY", test.env.failureRespBody)
 			tt.Setenv("SUCCESS_RESP_CODE", test.env.successRespCode)


### PR DESCRIPTION
**Description of the change**

This PR adds support for delayed responses configurable via the `RESP_DELAY` environment variable. It also adds support for customizing the log level via the `LOG_LEVEL` env. variable.

**Benefits**

Customization.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A
