### PR TITLE
feat: API error messages to follow standard by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,16 @@ USER 1001
 EXPOSE 8080
 ENV API_TOKEN="" \
     LOG_LEVEL="info" \
-    FAILURE_RESP_BODY="{\"success\": false}" \
+    FAILURE_RESP_BODY="" \
     FAILURE_RESP_CODE=400 \
     METHODS="GET,POST" \
     RESP_DELAY=0 \
     SUB_ROUTES="" \
-    SUCCESS_RESP_BODY="{\"success\": true}" \
+    SUCCESS_RESP_BODY="" \
     SUCCESS_RESP_CODE=200 \
     SUCCESS_RATIO=1.0 \
     RATE_LIMIT=1000 \
-    RATE_EXCEEDED_RESP_BODY="{\"success\": false, \"error\": \"rate limit exceeded\"}" \
+    RATE_EXCEEDED_RESP_BODY="" \
     PORT=8080
 
 ENTRYPOINT ["api-mock"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The API mock can be configured with the following environment variables:
 | `PORT` | The port to listen on | `8080` |
 | `LOG_LEVEL` | The log level | `info` |
 | `API_TOKEN` | Bearer token to authenticate requests | `` |
-| `FAILURE_RESP_BODY` | The response body to return when mocking a failure | `{"success": "false"}` |
+| `FAILURE_RESP_BODY` | The response body to return when mocking a failure | `{"error":{"message":"failed request","code":1005,"id":"[random-value]"}}` |
 | `FAILURE_RESP_CODE` | The HTTP status code to return when mocking a failure | `400` |
 | `SUCCESS_RESP_BODY` | The response body to return when mocking a success | `{"success": "true"}` |
 | `SUCCESS_RESP_CODE` | The HTTP status code to return when mocking a success | `200` |
@@ -39,7 +39,7 @@ The API mock can be configured with the following environment variables:
 | `RESP_DELAY` | The response delay (in milliseconds) | `0` |
 | `SUB_ROUTES` | The sub routes to mock | `` |
 | `RATE_LIMIT` | The API rate limit (requests per second) | `1000` |
-| `RATE_EXCEEDED_RESP_BODY` | The response body to return when mocking a rate exceeded | `{"success": "false", "error": "rate limit exceeded"}` |
+| `RATE_EXCEEDED_RESP_BODY` | The response body to return when mocking a rate exceeded | `{"error":{"message":"rate limit exceeded","code":1004,"id":"[random-value]"}}` |
 
 ## Build
 

--- a/cmd/api-mock/main.go
+++ b/cmd/api-mock/main.go
@@ -8,15 +8,12 @@ import (
 
 func main() {
 	// Init service
-	svcCfg, err := service.LoadConfigFromEnv()
-	if err != nil {
+	svc := service.NewService()
+	if err := svc.LoadConfig(); err != nil {
 		log.Fatal(err)
 	}
 
-	svc := service.Make(svcCfg)
-	svc.LogConfiguration()
-	svc.MakeRouter()
-
 	// Start service
+	svc.MakeRouter()
 	svc.ListenAndServe()
 }

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultPort      int     = 8080
+	defaultRateLimit int     = 1000
+	defaultRatio     float64 = 1.0
+)
+
+// loadConfigFromEnv loads the configuration from the environment.
+//
+//nolint:cyclop // many env variables to parse
+func loadConfigFromEnv() (*SvcConfig, error) {
+	var err error
+	cfg := SvcConfig{
+		apiToken: os.Getenv("API_TOKEN"),
+	}
+
+	portENV := os.Getenv("PORT")
+	if portENV != "" {
+		cfg.port, err = strconv.Atoi(portENV)
+		if err != nil {
+			return nil, fmt.Errorf("invalid int format for PORT: %w", err)
+		}
+	} else {
+		cfg.port = defaultPort
+	}
+
+	respDelayENV := os.Getenv("RESP_DELAY")
+	if respDelayENV != "" {
+		respDelayINT, err := strconv.Atoi(respDelayENV)
+		if err != nil {
+			return nil, fmt.Errorf("invalid int format for RESP_DELAY: %w", err)
+		}
+
+		cfg.respDelay = time.Duration(respDelayINT) * time.Millisecond
+		if cfg.respDelay > 30*time.Second {
+			return nil, fmt.Errorf("RESP_DELAY cannot be greater than 30 seconds")
+		}
+	}
+
+	failureCodeEnv := os.Getenv("FAILURE_RESP_CODE")
+	if failureCodeEnv != "" {
+		cfg.failureCode, err = strconv.Atoi(failureCodeEnv)
+		if err != nil {
+			return nil, fmt.Errorf("invalid int format for FAILURE_RESP_CODE: %w", err)
+		}
+	} else {
+		cfg.failureCode = http.StatusBadRequest // default response code
+	}
+
+	failureRespBodyEnv := os.Getenv("FAILURE_RESP_BODY")
+	if failureRespBodyEnv != "" {
+		if err = json.Unmarshal([]byte(failureRespBodyEnv), &cfg.failureRespBody); err != nil {
+			return nil, fmt.Errorf("invalid json format for FAILURE_RESP_BODY: %w", err)
+		}
+	}
+
+	successCodeEnv := os.Getenv("SUCCESS_RESP_CODE")
+	if successCodeEnv != "" {
+		cfg.successCode, err = strconv.Atoi(successCodeEnv)
+		if err != nil {
+			return nil, fmt.Errorf("invalid int format for SUCCESS_RESP_CODE: %w", err)
+		}
+	} else {
+		cfg.successCode = http.StatusOK // default response code
+	}
+
+	successRepBodyEnv := os.Getenv("SUCCESS_RESP_BODY")
+	if successRepBodyEnv != "" {
+		if err = json.Unmarshal([]byte(successRepBodyEnv), &cfg.successRespBody); err != nil {
+			return nil, fmt.Errorf("invalid json format for SUCCESS_RESP_BODY: %w", err)
+		}
+	} else {
+		cfg.successRespBody = map[string]interface{}{"success": true} // default response body
+	}
+
+	successRatioEnv := os.Getenv("SUCCESS_RATIO")
+	if successRatioEnv != "" {
+		cfg.successRatio, err = strconv.ParseFloat(successRatioEnv, 64)
+		if err != nil || cfg.successRatio <= 0 || cfg.successRatio > 1 {
+			return nil, fmt.Errorf("invalid value for SUCCESS_RATIO")
+		}
+	} else {
+		cfg.successRatio = defaultRatio
+	}
+
+	rateLimitEnv := os.Getenv("RATE_LIMIT")
+	if rateLimitEnv != "" {
+		cfg.rateLimit, err = strconv.Atoi(rateLimitEnv)
+		if err != nil {
+			return nil, fmt.Errorf("invalid int format for RATE_LIMIT")
+		}
+	} else {
+		cfg.rateLimit = defaultRateLimit
+	}
+
+	rateExceededRespBodyEnv := os.Getenv("RATE_EXCEEDED_RESP_BODY")
+	if rateExceededRespBodyEnv != "" {
+		if err = json.Unmarshal([]byte(rateExceededRespBodyEnv), &cfg.rateExceededRespBody); err != nil {
+			return nil, fmt.Errorf("invalid json format for RATE_EXCEEDED_RESP_BODY: %w", err)
+		}
+	}
+
+	methodsEnv := os.Getenv("METHODS")
+	if methodsEnv != "" {
+		allowedMethods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch}
+		cfg.methods = strings.Split(methodsEnv, ",")
+		for _, method := range cfg.methods {
+			if !stringSliceContains(allowedMethods, method) {
+				return nil, fmt.Errorf("method %s is not allowed", method)
+			}
+		}
+	}
+
+	subRoutesEnv := os.Getenv("SUB_ROUTES")
+	if subRoutesEnv != "" {
+		cfg.subRoutes = strings.Split(subRoutesEnv, ",")
+	}
+
+	return &cfg, nil
+}
+
+// stringSliceContains is a helper function to detect whether a string slice contains a string or not
+func stringSliceContains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+// structToMapStringInterface transforms a struct of the given type into a map[string]interface{}
+func structToMapStringInterface(s interface{}) (map[string]interface{}, error) {
+	if reflect.TypeOf(s).Kind() != reflect.Struct {
+		return nil, fmt.Errorf("s must be a struct")
+	}
+
+	buf, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+
+	var mapVal map[string]interface{}
+	if err = json.Unmarshal(buf, &mapVal); err != nil {
+		return nil, err
+	}
+
+	return mapVal, nil
+}

--- a/internal/service/config_test.go
+++ b/internal/service/config_test.go
@@ -21,12 +21,12 @@ func Test_loadConfigFromEnv(t *testing.T) {
 			want: &SvcConfig{
 				port:                 8080,
 				failureCode:          http.StatusBadRequest,
-				failureRespBody:      map[string]interface{}{"success": false},
+				failureRespBody:      nil,
 				successCode:          http.StatusOK,
 				successRespBody:      map[string]interface{}{"success": true},
 				successRatio:         1.0,
 				rateLimit:            1000,
-				rateExceededRespBody: map[string]interface{}{"success": false, "error": "rate limit exceeded"},
+				rateExceededRespBody: nil,
 			},
 			wantErr: false,
 		},
@@ -286,6 +286,7 @@ func TestStructToMapStringInterface(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	t.Parallel()
 	for _, testToRun := range tests {
 		test := testToRun
 		t.Run(test.name, func(tt *testing.T) {

--- a/internal/service/config_test.go
+++ b/internal/service/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func Test_LoadConfigFromEnv(t *testing.T) {
+func Test_loadConfigFromEnv(t *testing.T) {
 	type env struct {
 		port, apiToken, respDelay, failureRespCode, failureRespBody, successRespCode, successRespBody, successRatio, rateLimit, rateExceededRespBody, methods, subRoutes string
 	}
@@ -156,12 +156,147 @@ func Test_LoadConfigFromEnv(t *testing.T) {
 			tt.Setenv("METHODS", test.env.methods)
 			tt.Setenv("SUB_ROUTES", test.env.subRoutes)
 
-			got, err := LoadConfigFromEnv()
+			got, err := loadConfigFromEnv()
 			if (err != nil) != test.wantErr {
 				t.Errorf("LoadConfigFromEnv() error = %v, wantErr %v", err, test.wantErr)
 			}
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("LoadConfigFromEnv() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStringSliceContains(t *testing.T) {
+	type args struct {
+		s []string
+		e string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Successful search",
+			args: args{
+				s: []string{"one", "two", "three"},
+				e: "two",
+			},
+			want: true,
+		},
+		{
+			name: "Unsuccessful search",
+			args: args{
+				s: []string{"one", "two", "three"},
+				e: "four",
+			},
+			want: false,
+		},
+	}
+	t.Parallel()
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			if got := stringSliceContains(test.args.s, test.args.e); got != test.want {
+				tt.Errorf("StringSliceContains() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+type testStruct struct {
+	One   string
+	Two   int
+	Three bool
+	Four  []testSubStruct
+	Five  string
+}
+
+type testSubStruct struct {
+	Six string
+}
+
+type jsonStruct struct {
+	One   string        `json:"uno"`
+	Two   int           `json:"dos"`
+	Three bool          `json:"tres"`
+	Four  jsonSubStruct `json:"cuatro"`
+	Five  string        `json:"cinco"`
+}
+
+type jsonSubStruct struct {
+	Six string `json:"seis"`
+}
+
+func TestStructToMapStringInterface(t *testing.T) {
+	type args struct {
+		s interface{}
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name: "Successful transformation",
+			args: args{
+				s: testStruct{
+					One:   "one",
+					Two:   2,
+					Three: true,
+					Four:  nil,
+					Five:  "five",
+				},
+			},
+			want: map[string]interface{}{
+				"One":   "one",
+				"Two":   float64(2),
+				"Three": true,
+				"Four":  nil,
+				"Five":  "five",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Successful transformation (JSON)",
+			args: args{
+				s: jsonStruct{
+					One:   "one",
+					Two:   2,
+					Three: true,
+					Four: jsonSubStruct{
+						Six: "six",
+					},
+					Five: "five",
+				},
+			},
+			want: map[string]interface{}{
+				"uno":  "one",
+				"dos":  float64(2),
+				"tres": true,
+				"cuatro": map[string]interface{}{
+					"seis": "six",
+				},
+				"cinco": "five",
+			},
+			wantErr: false,
+		},
+	}
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			got, err := structToMapStringInterface(test.args.s)
+			if (err != nil) != test.wantErr {
+				tt.Errorf("StructToMapStringInterface() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				tt.Errorf("StructToMapStringInterface() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/internal/service/r_mock_test.go
+++ b/internal/service/r_mock_test.go
@@ -16,7 +16,6 @@ import (
 func Test_service_handleMock(t *testing.T) {
 	svc := &service{
 		cfg: &SvcConfig{
-			failureRespBody: map[string]interface{}{"success": false},
 			failureCode:     http.StatusBadRequest,
 			successRespBody: map[string]interface{}{"success": true},
 			successCode:     http.StatusOK,
@@ -70,15 +69,12 @@ func Test_service_handleMock(t *testing.T) {
 				if resp.Header().Get("Content-Type") != "application/json" {
 					tt.Errorf("expected content type %s, got %s", "application/json", resp.Header().Get("Content-Type"))
 				}
-				buf := &bytes.Buffer{}
-				enc := json.NewEncoder(buf)
-				enc.SetEscapeHTML(true)
-				err := enc.Encode(map[string]interface{}{"success": false})
-				if err != nil {
-					tt.Errorf("could not encode response body: %+v", err)
+				var errorResponse api.HTTPErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &errorResponse); err != nil {
+					tt.Errorf("could not unmarshal response body: %+v", err)
 				}
-				if resp.Body.String() != buf.String() {
-					tt.Errorf("expected body %s, got %s", buf.String(), resp.Body.String())
+				if errorResponse.Error.Message != "failed request" || errorResponse.Error.Code != api.CodeFailedRequest {
+					tt.Errorf("expected error message %s and code %d, got %s and %d", "failed request", api.CodeFailedRequest, errorResponse.Error.Message, errorResponse.Error.Code)
 				}
 			},
 		},
@@ -120,26 +116,25 @@ func Test_service_handleMock(t *testing.T) {
 }
 
 func Test_service_handleBatchMock(t *testing.T) {
-	svc := &service{
-		cfg: &SvcConfig{
-			failureRespBody: map[string]interface{}{"success": false},
-			failureCode:     http.StatusBadRequest,
-			successRespBody: map[string]interface{}{"success": true},
-			successCode:     http.StatusOK,
-			successRatio:    0.5,
-			methods:         []string{http.MethodGet},
-			subRoutes:       []string{"/foo"},
-		},
-		logger: newStructuredLogger(slog.LevelDebug),
-	}
-
 	tests := []struct {
 		name         string
+		svc          *service
 		setupRequest func() *http.Request
 		respHandler  func(tt *testing.T, resp *httptest.ResponseRecorder)
 	}{
 		{
-			name: "success batch request",
+			name: "success batch request with custom response body",
+			svc: &service{
+				cfg: &SvcConfig{
+					failureCode:     http.StatusBadRequest,
+					successRespBody: map[string]interface{}{"success": true},
+					successCode:     http.StatusOK,
+					successRatio:    0.5,
+					methods:         []string{http.MethodGet},
+					subRoutes:       []string{"/foo"},
+				},
+				logger: newStructuredLogger(slog.LevelDebug),
+			},
 			setupRequest: func() *http.Request {
 				reqBody := `[{
 					"method": "GET",
@@ -167,15 +162,85 @@ func Test_service_handleBatchMock(t *testing.T) {
 				if resp.Header().Get("Content-Type") != "application/json" {
 					tt.Errorf("expected content type %s, got %s", "application/json", resp.Header().Get("Content-Type"))
 				}
-				buf := &bytes.Buffer{}
-				enc := json.NewEncoder(buf)
-				enc.SetEscapeHTML(true)
-				err := enc.Encode([]api.BatchResponse{{Code: 200, Body: "{\"success\":true}"}, {Code: 400, Body: "{\"success\":false}"}})
-				if err != nil {
-					tt.Errorf("could not encode response body: %+v", err)
+				var batchResponse []api.BatchResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &batchResponse); err != nil {
+					tt.Errorf("could not unmarshal response body: %+v", err)
 				}
-				if resp.Body.String() != buf.String() {
-					tt.Errorf("expected body %s, got %s", buf.String(), resp.Body.String())
+
+				if len(batchResponse) != 2 {
+					tt.Errorf("expected batch response length %d, got %d", 2, len(batchResponse))
+				}
+
+				if batchResponse[0].Code != 200 || batchResponse[0].Body != "{\"success\":true}" {
+					tt.Errorf("expected response code %d and body %s, got %d and %s", 200, "{\"success\":true}", batchResponse[0].Code, batchResponse[0].Body)
+				}
+
+				if batchResponse[1].Code != 400 {
+					tt.Errorf("expected response code %d, got %d", 400, batchResponse[1].Code)
+				}
+
+				var errorResponse api.HTTPErrorResponse
+				if err := json.Unmarshal([]byte(batchResponse[1].Body), &errorResponse); err != nil {
+					tt.Errorf("could not unmarshal response body: %+v", err)
+				}
+
+				if errorResponse.Error.Message != "failed request" || errorResponse.Error.Code != api.CodeFailedRequest {
+					tt.Errorf("expected error message %s and code %d, got %s and %d", "failed request", api.CodeFailedRequest, errorResponse.Error.Message, errorResponse.Error.Code)
+				}
+			},
+		},
+		{
+			name: "success batch request with custom failure response body",
+			svc: &service{
+				cfg: &SvcConfig{
+					failureRespBody: map[string]interface{}{"success": false},
+					failureCode:     http.StatusBadRequest,
+					successRespBody: map[string]interface{}{"success": true},
+					successCode:     http.StatusOK,
+					successRatio:    0.5,
+					methods:         []string{http.MethodGet},
+					subRoutes:       []string{"/foo"},
+				},
+				logger: newStructuredLogger(slog.LevelDebug),
+			},
+			setupRequest: func() *http.Request {
+				reqBody := `[{
+					"method": "GET",
+					"relative_url": "/foo",
+					"body": null
+				}, {
+					"method": "GET",
+					"relative_url": "/bar",
+					"body": null
+				}]`
+				encodedBody := url.Values{}
+				encodedBody.Set("batch", reqBody)
+
+				req := httptest.NewRequest(
+					http.MethodPost,
+					"/v1/mock/batch",
+					strings.NewReader(encodedBody.Encode()),
+				)
+				return req
+			},
+			respHandler: func(tt *testing.T, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusOK {
+					tt.Errorf("expected status code %d, got %d", http.StatusOK, resp.Code)
+				}
+				if resp.Header().Get("Content-Type") != "application/json" {
+					tt.Errorf("expected content type %s, got %s", "application/json", resp.Header().Get("Content-Type"))
+				}
+				var batchResponse []api.BatchResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &batchResponse); err != nil {
+					tt.Errorf("could not unmarshal response body: %+v", err)
+				}
+
+				if batchResponse[0].Code != 200 || batchResponse[0].Body != "{\"success\":true}" {
+					tt.Errorf("expected response code %d and body %s, got %d and %s", 200, "{\"success\":true}", batchResponse[0].Code, batchResponse[0].Body)
+				}
+
+				if batchResponse[1].Code != 400 || batchResponse[1].Body != "{\"success\":false}" {
+					tt.Errorf("expected response code %d and body %s, got %d and %s", 400, "{\"success\":false}", batchResponse[1].Code, batchResponse[1].Body)
 				}
 			},
 		},
@@ -186,8 +251,8 @@ func Test_service_handleBatchMock(t *testing.T) {
 		t.Run(test.name, func(tt *testing.T) {
 			tt.Parallel()
 			resp := httptest.NewRecorder()
-			svc.reqCounter++
-			svc.handleBatchMock(resp, test.setupRequest())
+			test.svc.reqCounter++
+			test.svc.handleBatchMock(resp, test.setupRequest())
 			test.respHandler(tt, resp)
 		})
 	}
@@ -278,6 +343,84 @@ func Test_handleMethodNotAllowed(t *testing.T) {
 			tt.Parallel()
 			resp := httptest.NewRecorder()
 			svc.handleMethodNotAllowed(resp, test.setupRequest())
+			test.respHandler(tt, resp)
+		})
+	}
+}
+
+func Test_handleRateLimitExceeded(t *testing.T) {
+	tests := []struct {
+		name         string
+		svc          *service
+		setupRequest func() *http.Request
+		respHandler  func(tt *testing.T, resp *httptest.ResponseRecorder)
+	}{
+		{
+			name: "request limit exceeded with default response body",
+			svc: &service{
+				logger: newStructuredLogger(slog.LevelDebug),
+				cfg:    &SvcConfig{},
+			},
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/v1/mock/unknown", nil)
+				return req
+			},
+			respHandler: func(tt *testing.T, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusTooManyRequests {
+					tt.Errorf("expected status code %d, got %d", http.StatusTooManyRequests, resp.Code)
+				}
+				if resp.Header().Get("Content-Type") != "application/json" {
+					tt.Errorf("expected content type %s, got %s", "application/json", resp.Header().Get("Content-Type"))
+				}
+				var errorResponse api.HTTPErrorResponse
+				if err := json.Unmarshal(resp.Body.Bytes(), &errorResponse); err != nil {
+					tt.Errorf("could not unmarshal response body: %+v", err)
+				}
+
+				if errorResponse.Error.Message != "rate limit exceeded" || errorResponse.Error.Code != api.CodeRateLimitExceeded {
+					tt.Errorf("expected error message %s and code %d, got %s and %d", "rate limit exceeded", api.CodeRateLimitExceeded, errorResponse.Error.Message, errorResponse.Error.Code)
+				}
+			},
+		},
+		{
+			name: "request limit exceeded with custom response body",
+			svc: &service{
+				logger: newStructuredLogger(slog.LevelDebug),
+				cfg: &SvcConfig{
+					rateExceededRespBody: map[string]interface{}{"success": false},
+				},
+			},
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/v1/mock/unknown", nil)
+				return req
+			},
+			respHandler: func(tt *testing.T, resp *httptest.ResponseRecorder) {
+				if resp.Code != http.StatusTooManyRequests {
+					tt.Errorf("expected status code %d, got %d", http.StatusTooManyRequests, resp.Code)
+				}
+				if resp.Header().Get("Content-Type") != "application/json" {
+					tt.Errorf("expected content type %s, got %s", "application/json", resp.Header().Get("Content-Type"))
+				}
+				buf := &bytes.Buffer{}
+				enc := json.NewEncoder(buf)
+				enc.SetEscapeHTML(true)
+				err := enc.Encode(map[string]interface{}{"success": false})
+				if err != nil {
+					tt.Errorf("could not encode response body: %+v", err)
+				}
+				if resp.Body.String() != buf.String() {
+					tt.Errorf("expected body %s, got %s", buf.String(), resp.Body.String())
+				}
+			},
+		},
+	}
+	t.Parallel()
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			resp := httptest.NewRecorder()
+			test.svc.handleRateLimitExceeded(resp, test.setupRequest())
 			test.respHandler(tt, resp)
 		})
 	}

--- a/pkg/api/codes.go
+++ b/pkg/api/codes.go
@@ -2,8 +2,10 @@ package api
 
 const (
 	// 1xxx errors
-	requestBase          = 1000
-	CodeInvalidBody      = requestBase + 1
-	CodeNotFound         = requestBase + 2
-	CodeMethodNotAllowed = requestBase + 3
+	requestBase           = 1000
+	CodeInvalidBody       = requestBase + 1
+	CodeNotFound          = requestBase + 2
+	CodeMethodNotAllowed  = requestBase + 3
+	CodeRateLimitExceeded = requestBase + 4
+	CodeFailedRequest     = requestBase + 5
 )


### PR DESCRIPTION
**Description of the change**

This PR ensures that, by default, the API error messages (e.g. when a failure is programmed or API rate limit is exceeded) follow the standard error format by default.

**Benefits**

Standardization with other API errors (e.g. "BadRequest" errors on batch requests).

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A
