### PR TITLE
feat: add support for API key authn

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The API mock can be configured with the following environment variables:
 | -------- | ----------- | ------- |
 | `PORT` | The port to listen on | `8080` |
 | `LOG_LEVEL` | The log level | `info` |
+| `API_KEY` | API key to authenticate requests via `X-API-KEY` header | `` |
 | `API_TOKEN` | Bearer token to authenticate requests | `` |
 | `FAILURE_RESP_BODY` | The response body to return when mocking a failure | `{"error":{"message":"failed request","code":1005,"id":"[random-value]"}}` |
 | `FAILURE_RESP_CODE` | The HTTP status code to return when mocking a failure | `400` |

--- a/internal/service/config_test.go
+++ b/internal/service/config_test.go
@@ -8,17 +8,17 @@ import (
 
 func Test_loadConfigFromEnv(t *testing.T) {
 	type env struct {
-		port, apiToken, respDelay, failureRespCode, failureRespBody, successRespCode, successRespBody, successRatio, rateLimit, rateExceededRespBody, methods, subRoutes string
+		port, apiKey, apiToken, respDelay, failureRespCode, failureRespBody, successRespCode, successRespBody, successRatio, rateLimit, rateExceededRespBody, methods, subRoutes string
 	}
 	tests := []struct {
 		name    string
 		env     env
-		want    *SvcConfig
+		want    *config
 		wantErr bool
 	}{
 		{
 			name: "Valid configuration (defaults)",
-			want: &SvcConfig{
+			want: &config{
 				port:                 8080,
 				failureCode:          http.StatusBadRequest,
 				failureRespBody:      nil,
@@ -45,7 +45,7 @@ func Test_loadConfigFromEnv(t *testing.T) {
 				methods:              "GET,POST,PUT",
 				subRoutes:            "/foo,/bar",
 			},
-			want: &SvcConfig{
+			want: &config{
 				port:                 8080,
 				apiToken:             "some-token",
 				failureCode:          http.StatusBadRequest,
@@ -59,6 +59,15 @@ func Test_loadConfigFromEnv(t *testing.T) {
 				subRoutes:            []string{"/foo", "/bar"},
 			},
 			wantErr: false,
+		},
+		{
+			name: "Both API key and token set",
+			env: env{
+				apiKey:   "some-key",
+				apiToken: "some-token",
+			},
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "Invalid port",
@@ -144,6 +153,7 @@ func Test_loadConfigFromEnv(t *testing.T) {
 		test := testToRun
 		t.Run(test.name, func(tt *testing.T) {
 			tt.Setenv("PORT", test.env.port)
+			tt.Setenv("API_KEY", test.env.apiKey)
 			tt.Setenv("API_TOKEN", test.env.apiToken)
 			tt.Setenv("RESP_DELAY", test.env.respDelay)
 			tt.Setenv("FAILURE_RESP_CODE", test.env.failureRespCode)

--- a/internal/service/r_mock_test.go
+++ b/internal/service/r_mock_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_service_handleMock(t *testing.T) {
 	svc := &service{
-		cfg: &SvcConfig{
+		cfg: &config{
 			failureCode:     http.StatusBadRequest,
 			successRespBody: map[string]interface{}{"success": true},
 			successCode:     http.StatusOK,
@@ -125,7 +125,7 @@ func Test_service_handleBatchMock(t *testing.T) {
 		{
 			name: "success batch request with custom response body",
 			svc: &service{
-				cfg: &SvcConfig{
+				cfg: &config{
 					failureCode:     http.StatusBadRequest,
 					successRespBody: map[string]interface{}{"success": true},
 					successCode:     http.StatusOK,
@@ -192,7 +192,7 @@ func Test_service_handleBatchMock(t *testing.T) {
 		{
 			name: "success batch request with custom failure response body",
 			svc: &service{
-				cfg: &SvcConfig{
+				cfg: &config{
 					failureRespBody: map[string]interface{}{"success": false},
 					failureCode:     http.StatusBadRequest,
 					successRespBody: map[string]interface{}{"success": true},
@@ -359,7 +359,7 @@ func Test_handleRateLimitExceeded(t *testing.T) {
 			name: "request limit exceeded with default response body",
 			svc: &service{
 				logger: newStructuredLogger(slog.LevelDebug),
-				cfg:    &SvcConfig{},
+				cfg:    &config{},
 			},
 			setupRequest: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, "/v1/mock/unknown", nil)
@@ -386,7 +386,7 @@ func Test_handleRateLimitExceeded(t *testing.T) {
 			name: "request limit exceeded with custom response body",
 			svc: &service{
 				logger: newStructuredLogger(slog.LevelDebug),
-				cfg: &SvcConfig{
+				cfg: &config{
 					rateExceededRespBody: map[string]interface{}{"success": false},
 				},
 			},

--- a/internal/service/router.go
+++ b/internal/service/router.go
@@ -43,6 +43,9 @@ func (svc *service) MakeRouter() {
 		r.MethodNotAllowed(svc.handleMethodNotAllowed)
 
 		r.Use(svc.RequestLogger())
+		if svc.cfg.apiKey != "" {
+			r.Use(authn.ApiKeyAuth(svc.cfg.apiKey))
+		}
 		if svc.cfg.apiToken != "" {
 			r.Use(authn.BearerTokenAuth(svc.cfg.apiToken))
 		}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -26,26 +26,11 @@ type Service interface {
 }
 
 type service struct {
-	cfg        *SvcConfig   // service configuration
+	cfg        *config      // service configuration
 	router     *chi.Mux     // http router
 	reqCounter int          // request counter
 	mu         sync.Mutex   // Mutual exclusion lock
 	logger     *slog.Logger // logger
-}
-
-// SvcConfig is the service configuration
-type SvcConfig struct {
-	port                 int                    // server listening port
-	apiToken             string                 // api token
-	methods, subRoutes   []string               // supported sub-routes
-	respDelay            time.Duration          // response delay in milliseconds
-	failureCode          int                    // response code for failed requests
-	failureRespBody      map[string]interface{} // response body for failed requests
-	successCode          int                    // response code for successful requests
-	successRespBody      map[string]interface{} // response body for successful requests
-	successRatio         float64                // ratio of successful requests
-	rateLimit            int                    // rate limit (requests per second)
-	rateExceededRespBody map[string]interface{} // response body for rate exceeded requests
 }
 
 // NewService creates a new service

--- a/pkg/authn/authn.go
+++ b/pkg/authn/authn.go
@@ -7,6 +7,20 @@ import (
 
 const authenticateHeader string = `Bearer realm="example", error="invalid_token", error_description="invalid access token"`
 
+// ApiKeyAuth implements a simple middleware handler for adding
+// authentication based on an API key set in the X-API-KEY header.
+func ApiKeyAuth(key string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("X-API-KEY") != key {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // BearerTokenAuth implements a simple middleware handler for adding
 // bearer http auth based on tokens to a route.
 func BearerTokenAuth(token string) func(next http.Handler) http.Handler {

--- a/pkg/authn/authn_test.go
+++ b/pkg/authn/authn_test.go
@@ -9,7 +9,56 @@ import (
 	"github.com/go-chi/chi"
 )
 
+const defaultKey string = "some-key"
 const defaultToken string = "some-token"
+
+func TestApiKeyAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		want       int
+	}{
+		{
+			"valid auth",
+			defaultKey,
+			http.StatusOK,
+		},
+		{
+			"missing key",
+			"",
+			http.StatusUnauthorized,
+		},
+		{
+			"invalid key",
+			"foo",
+			http.StatusUnauthorized,
+		},
+	}
+	t.Parallel()
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+
+			r := chi.NewRouter()
+			r.Use(ApiKeyAuth(defaultKey))
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("X-API-KEY", test.authHeader)
+			recorder := httptest.NewRecorder()
+			r.ServeHTTP(recorder, req)
+			res := recorder.Result()
+			defer res.Body.Close()
+
+			if res.StatusCode != test.want {
+				tt.Errorf("response status code is incorrect, got %d, want %d", res.StatusCode, test.want)
+			}
+		})
+	}
+}
 
 func TestBearerTokenAuth(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**Description of the change**

This PR adds support for customizing the API mock so it request API key authn to access (via `X-API-KEY` header).

**Benefits**

Flexibility.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A