### PR TITLE
feat: add integration test example with Cypress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY dist/api-mock_linux_${TARGETARCH}*/api-mock /usr/local/bin/
 # by default, use a non-root (non-privileged) UID to run the container
 USER 1001
 EXPOSE 8080
-ENV API_TOKEN="" \
+ENV API_KEY="" \
+    API_TOKEN="" \
     LOG_LEVEL="info" \
     FAILURE_RESP_BODY="" \
     FAILURE_RESP_CODE=400 \

--- a/examples/integration/cypress.config.js
+++ b/examples/integration/cypress.config.js
@@ -1,0 +1,10 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://api-mock:8080',
+    screenshotOnRunFailure: false,
+    supportFile: false,
+    video: false,
+  }
+})

--- a/examples/integration/cypress/e2e/spec.cy.js
+++ b/examples/integration/cypress/e2e/spec.cy.js
@@ -1,0 +1,71 @@
+describe('API mock', () => {
+  it('Heartbeat & metrics endpoints', () => {
+    cy.request('/live').as('getLive');
+    cy.get('@getLive').then(res => {
+      expect(res.status).to.eq(200);
+    });
+    cy.request('/ready').as('getReady');
+    cy.get('@getReady').then(res => {
+      expect(res.status).to.eq(200);
+    });
+  });
+
+  it('API endpoints (authn)', () => {
+    cy.request({
+      method: 'GET',
+      url: '/v1/mock/foo',
+      failOnStatusCode: false,
+    }).as('noAuthn');
+    cy.get('@noAuthn').then(res => {
+      expect(res.status).to.eq(401);
+    });
+    cy.request({
+      method: 'GET',
+      url: '/v1/mock/foo',
+      headers: {'X-API-KEY': 'some-api-key'},
+      failOnStatusCode: false,
+    }).as('getFoo');
+    cy.get('@getFoo').then(res => {
+      expect(res.status).to.eq(200);
+      expect(res.body).to.have.property('message');
+      expect(res.body.message).to.eq('success');
+    });
+  });
+
+  it('API endpoints (success ratio)', () => {
+    cy.request({
+      method: 'GET',
+      url: '/v1/mock/foo',
+      headers: {'X-API-KEY': 'some-api-key'},
+      failOnStatusCode: false,
+    }).as('resetCounter');
+    cy.get('@resetCounter').then(res => {
+      cy.request({
+        method: 'GET',
+        url: '/v1/mock/bar',
+        headers: {'X-API-KEY': 'some-api-key'},
+        failOnStatusCode: false,
+      }).as('getBar');
+      cy.get('@getBar').then(res => {
+        expect(res.status).to.eq(200);
+        expect(res.body).to.have.property('message');
+        expect(res.body.message).to.eq('success');
+        cy.request({
+          method: 'POST',
+          url: '/v1/mock/bar',
+          headers: {'X-API-KEY': 'some-api-key'},
+          body: JSON.stringify({foo: 'bar'}),
+          failOnStatusCode: false,
+        }).as('postBar');
+        cy.get('@postBar').then(res => {
+          expect(res.status).to.eq(400);
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.have.property('code');
+          expect(res.body.error).to.have.property('message');
+          expect(res.body.error.code).to.eq(1005);
+          expect(res.body.error.message).to.eq('failed request');
+        });
+      });
+    });
+  });
+});

--- a/examples/integration/docker-compose.yaml
+++ b/examples/integration/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: '3.5'
+
+services:
+  api-mock:
+    image: docker.io/juanariza131/api-mock:latest
+    environment:
+      API_KEY: some-api-key
+      LOG_LEVEL: debug
+      RATE_LIMIT: 100
+      SUCCESS_RATIO: 0.5
+      SUCCESS_RESP_BODY: "{\"message\": \"success\"}"
+      SUB_ROUTES: "/foo,/bar"
+  cypress:
+    image: cypress/included:10.6.0
+    depends_on:
+      api-mock:
+        condition: service_started
+    working_dir: /e2e
+    volumes:
+      - ./:/e2e


### PR DESCRIPTION
**Description of the change**

This PR adds an example of how to use the API mock container image to write a simple integration test using Cypress.

**Benefits**

Docs.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A
