### PR TITLE
feat: use go-cmp for testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/httprate v0.7.4
 	github.com/go-chi/render v1.0.3
+	github.com/google/go-cmp v0.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,5 @@ github.com/go-chi/httprate v0.7.4 h1:a2GIjv8he9LRf3712zxxnRdckQCm7I8y8yQhkJ84V6M
 github.com/go-chi/httprate v0.7.4/go.mod h1:6GOYBSwnpra4CQfAKXu8sQZg+nZ0M1g9QnyFvxrAB8A=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
 github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/internal/service/config_test.go
+++ b/internal/service/config_test.go
@@ -2,8 +2,9 @@ package service
 
 import (
 	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_loadConfigFromEnv(t *testing.T) {
@@ -170,7 +171,7 @@ func Test_loadConfigFromEnv(t *testing.T) {
 			if (err != nil) != test.wantErr {
 				t.Errorf("LoadConfigFromEnv() error = %v, wantErr %v", err, test.wantErr)
 			}
-			if !reflect.DeepEqual(got, test.want) {
+			if !cmp.Equal(got, test.want, cmp.AllowUnexported(config{})) {
 				t.Errorf("LoadConfigFromEnv() = %v, want %v", got, test.want)
 			}
 		})
@@ -306,7 +307,7 @@ func TestStructToMapStringInterface(t *testing.T) {
 				tt.Errorf("StructToMapStringInterface() error = %v, wantErr %v", err, test.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, test.want) {
+			if !cmp.Equal(got, test.want) {
 				tt.Errorf("StructToMapStringInterface() = %v, want %v", got, test.want)
 			}
 		})


### PR DESCRIPTION
**Description of the change**

This PR replaces `reflect.DeepEqual` with `cmp.Equal` on tests.

**Benefits**

[go-cmp](https://github.com/google/go-cmp) is a a more powerful and safer alternative to `reflect.DeepEqual` for comparing whether two values are semantically equal.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A
